### PR TITLE
feat:LeanStateSearch Support

### DIFF
--- a/LeanSearchClient/Basic.lean
+++ b/LeanSearchClient/Basic.lean
@@ -20,6 +20,11 @@ register_option statesearch.queries : Nat :=
     group := "statesearch"
     descr := "Number of results requested from statesearch (default 6)" }
 
+register_option statesearch.revision : String :=
+  { defValue := s!"v{Lean.versionString}"
+    group := "statesearch"
+    descr := "Revision of LeanStateSearch to use" }
+
 register_option leansearchclient.useragent : String :=
   { defValue := "LeanSearchClient"
     group := "leansearchclient"

--- a/LeanSearchClient/Basic.lean
+++ b/LeanSearchClient/Basic.lean
@@ -15,6 +15,11 @@ register_option loogle.queries : Nat :=
     group := "loogle"
     descr := "Number of results requested from loogle (default 6)" }
 
+register_option statesearch.queries : Nat :=
+  { defValue := 6
+    group := "statesearch"
+    descr := "Number of results requested from statesearch (default 6)" }
+
 register_option leansearchclient.useragent : String :=
   { defValue := "LeanSearchClient"
     group := "leansearchclient"

--- a/LeanSearchClient/Syntax.lean
+++ b/LeanSearchClient/Syntax.lean
@@ -417,17 +417,15 @@ syntax (name := moogle_search_tactic)
   | _ => throwUnsupportedSyntax
 
 /-- Search [LeanStateSearch](https://premise-search.com) from within Lean.
-Your current main goal is sent as query. You can specify a revision. The number
-of results can be set using the `statesearch.queries` option.
+Your current main goal is sent as query. The revision to search can be set
+using the `statesearch.revision` option. The number of results can be set
+using the `statesearch.queries` option.
 
 Hint: If you want to modify the query, you need to use the web interface.
 
 ```lean
 set_option statesearch.queries 1
-
-example : 0 ≤ 1 := by
-  #statesearch "v4.16.0"
-  sorry
+set_option statesearch.revision "v4.16.0"
 
 example : 0 ≤ 1 := by
   #statesearch
@@ -435,21 +433,16 @@ example : 0 ≤ 1 := by
 ```
 -/
 syntax (name := statesearch_search_tactic)
-  withPosition("#statesearch" (str)?) : tactic
+  withPosition("#statesearch") : tactic
 
 @[tactic statesearch_search_tactic] def stateSearchTacticImpl : Tactic :=
   fun stx => withMainContext do
   let goal ← getMainGoal
   let state := (← Meta.ppGoal goal).pretty
   let num_results := (statesearch.queries.get (← getOptions))
+  let rev := (statesearch.revision.get (← getOptions))
   match stx with
-  | `(tactic|#statesearch $rev:str) =>
-    let rev := rev.getString
-    let results ← queryStateSearch state num_results rev
-    let suggestions := results.map SearchResult.toCommandSuggestion
-    TryThis.addSuggestions stx suggestions
   | `(tactic|#statesearch) =>
-    let rev := s!"v{Lean.versionString}"
     let results ← queryStateSearch state num_results rev
     let suggestions := results.map SearchResult.toCommandSuggestion
     TryThis.addSuggestions stx suggestions

--- a/LeanSearchClient/Syntax.lean
+++ b/LeanSearchClient/Syntax.lean
@@ -417,13 +417,14 @@ syntax (name := moogle_search_tactic)
   | _ => throwUnsupportedSyntax
 
 /-- Search [LeanStateSearch](https://premise-search.com) from within Lean.
-Your current main goal is sent as query. You can specify the revision
-and number of results, which are your current Lean version and 6 respectively
-by default.
+Your current main goal is sent as query. You can specify a revision. The number
+of results can be set using the `statesearch.queries` option.
 
 Hint: If you want to modify the query, you need to use the web interface.
 
 ```lean
+set_option statesearch.queries 1
+
 example : 0 ≤ 1 := by
   #statesearch "v4.16.0"
   sorry

--- a/LeanSearchClient/Syntax.lean
+++ b/LeanSearchClient/Syntax.lean
@@ -108,7 +108,13 @@ def getStateSearchQueryJson (s : String) (num_results : Nat := 6) (rev : String)
       stateSearchCache.modify fun m => m.insert (s, num_results, rev) jsArr
       return jsArr
     | Except.error e =>
-      IO.throwServerError s!"Could not obtain array from {js}; error: {e}"
+      let .ok err := js.getObjVal? "error"
+        | IO.throwServerError s!"{e}"
+      let .ok schema := js.getObjVal? "schema"
+        | IO.throwServerError s!"{e}"
+      let .ok desc := schema.getObjVal? "description"
+        | IO.throwServerError s!"{e}"
+      IO.throwServerError s!"error: {err}\ndescription: {desc}"
 
 structure SearchResult where
   name : String

--- a/LeanSearchClient/Syntax.lean
+++ b/LeanSearchClient/Syntax.lean
@@ -425,10 +425,6 @@ Hint: If you want to modify the query, you need to use the web interface.
 
 ```lean
 example : 0 ≤ 1 := by
-  #statesearch "v4.16.0" 10
-  sorry
-
-example : 0 ≤ 1 := by
   #statesearch "v4.16.0"
   sorry
 
@@ -438,28 +434,21 @@ example : 0 ≤ 1 := by
 ```
 -/
 syntax (name := statesearch_search_tactic)
-  withPosition("#statesearch" (str)? (num)?) : tactic
+  withPosition("#statesearch" (str)?) : tactic
 
 @[tactic statesearch_search_tactic] def stateSearchTacticImpl : Tactic :=
   fun stx => withMainContext do
   let goal ← getMainGoal
   let state := (← Meta.ppGoal goal).pretty
+  let num_results := (statesearch.queries.get (← getOptions))
   match stx with
-  | `(tactic|#statesearch $rev:str $n:num) =>
-    let rev := rev.getString
-    let num_results := n.getNat
-    let results ← queryStateSearch state num_results rev
-    let suggestions := results.map SearchResult.toCommandSuggestion
-    TryThis.addSuggestions stx suggestions
   | `(tactic|#statesearch $rev:str) =>
     let rev := rev.getString
-    let num_results := 6
     let results ← queryStateSearch state num_results rev
     let suggestions := results.map SearchResult.toCommandSuggestion
     TryThis.addSuggestions stx suggestions
   | `(tactic|#statesearch) =>
     let rev := s!"v{Lean.versionString}"
-    let num_results := 6
     let results ← queryStateSearch state num_results rev
     let suggestions := results.map SearchResult.toCommandSuggestion
     TryThis.addSuggestions stx suggestions

--- a/LeanSearchClientTest/StateSearchExamples.lean
+++ b/LeanSearchClientTest/StateSearchExamples.lean
@@ -1,0 +1,38 @@
+import LeanSearchClient.Syntax
+
+/-!
+# LeanStateSearch Examples
+
+Examples of using LeanStateSearch API. The search is triggered by the
+tactic `#statesearch`.
+-/
+
+set_option statesearch.queries 1
+
+/-- info: Try these:
+• #check Int.one_nonneg
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : 1 ≤ 0 := by
+  #statesearch "v4.16.0"
+  sorry
+
+/-- error: Could not obtain array from {"schema":
+ {"description": "Lean State Search does not support the specified revision"},
+ "error": "Invalid parameter value"}; error: array expected
+-/
+#guard_msgs in
+example : 1 ≤ 0 := by
+  #statesearch "v4.15.0"
+
+/-- info: Try these:
+• #check Int.one_nonneg
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : 1 ≤ 0 := by
+  #statesearch
+  sorry

--- a/LeanSearchClientTest/StateSearchExamples.lean
+++ b/LeanSearchClientTest/StateSearchExamples.lean
@@ -7,7 +7,7 @@ Examples of using LeanStateSearch API. The search is triggered by the
 tactic `#statesearch`.
 -/
 
-set_option statesearch.queries 1
+set_option statesearch.queries 1 -- set the number of results to 1
 
 /-- info: Try these:
 • #check Int.one_nonneg
@@ -15,7 +15,7 @@ set_option statesearch.queries 1
 warning: declaration uses 'sorry'
 -/
 #guard_msgs in
-example : 1 ≤ 0 := by
+example : 0 ≤ 1 := by
   #statesearch "v4.16.0"
   sorry
 
@@ -24,7 +24,7 @@ example : 1 ≤ 0 := by
  "error": "Invalid parameter value"}; error: array expected
 -/
 #guard_msgs in
-example : 1 ≤ 0 := by
+example : 0 ≤ 1 := by
   #statesearch "v4.15.0"
 
 /-- info: Try these:

--- a/LeanSearchClientTest/StateSearchExamples.lean
+++ b/LeanSearchClientTest/StateSearchExamples.lean
@@ -8,6 +8,7 @@ tactic `#statesearch`.
 -/
 
 set_option statesearch.queries 1 -- set the number of results to 1
+set_option statesearch.revision "v4.16.0" -- set the revision to v4.16.0
 
 /-- info: Try these:
 • #check Int.one_nonneg
@@ -16,8 +17,10 @@ warning: declaration uses 'sorry'
 -/
 #guard_msgs in
 example : 0 ≤ 1 := by
-  #statesearch "v4.16.0"
+  #statesearch
   sorry
+
+set_option statesearch.revision "v4.15.0"
 
 /-- error: Could not obtain array from {"schema":
  {"description": "Lean State Search does not support the specified revision"},
@@ -25,14 +28,4 @@ example : 0 ≤ 1 := by
 -/
 #guard_msgs in
 example : 0 ≤ 1 := by
-  #statesearch "v4.15.0"
-
-/-- info: Try these:
-• #check Int.one_nonneg
----
-warning: declaration uses 'sorry'
--/
-#guard_msgs in
-example : 1 ≤ 0 := by
   #statesearch
-  sorry

--- a/LeanSearchClientTest/StateSearchExamples.lean
+++ b/LeanSearchClientTest/StateSearchExamples.lean
@@ -22,9 +22,8 @@ example : 0 ≤ 1 := by
 
 set_option statesearch.revision "v4.15.0"
 
-/-- error: Could not obtain array from {"schema":
- {"description": "Lean State Search does not support the specified revision"},
- "error": "Invalid parameter value"}; error: array expected
+/-- error: error: "Invalid parameter value"
+description: "Lean State Search does not support the specified revision"
 -/
 #guard_msgs in
 example : 0 ≤ 1 := by

--- a/LeanSearchClientTest/StateSearchExamples.lean
+++ b/LeanSearchClientTest/StateSearchExamples.lean
@@ -7,16 +7,31 @@ Examples of using LeanStateSearch API. The search is triggered by the
 tactic `#statesearch`.
 -/
 
-set_option statesearch.queries 1 -- set the number of results to 1
+set_option statesearch.queries 1 -- set the number of results to 6
 set_option statesearch.revision "v4.16.0" -- set the revision to v4.16.0
 
+
 /-- info: Try these:
-• #check Int.one_nonneg
+• #check Int.one_pos
 ---
 warning: declaration uses 'sorry'
 -/
 #guard_msgs in
-example : 0 ≤ 1 := by
+example : 0 < 1 := by
+  #statesearch
+  sorry
+
+set_option statesearch.queries 6
+
+/--
+info: From: Nat.zero_lt_one (type: 0 < 1)
+• apply Nat.zero_lt_one
+• have : 0 < 1 := Nat.zero_lt_one
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : 0 < 1 := by
   #statesearch
   sorry
 


### PR DESCRIPTION
This PR adds functionality to use [LeanStateSearch](https://premise-search.com) API from within Lean. More specifically, tactic `#statesearch` is added.