### PR TITLE
chore: bump toolchain to v4.32.0

### DIFF
--- a/LeanSearchClientTest/Examples.lean
+++ b/LeanSearchClientTest/Examples.lean
@@ -24,6 +24,11 @@ Note this command sends your query to an external service at https://leansearch.
 #guard_msgs in
 example := #leansearch "If a natural number n is less than m, then the successor of n is less than the successor of m"
 
+-- The test below is disabled: it asserts on the suggestions returned by the live
+-- leansearch.net service, which drift over time. Currently the top result for this query
+-- elaborates only with Mathlib imported, so all suggestions are filtered out and no
+-- results are displayed at all.
+/-
 -- Sleep to avoid rate limiting (1 per 1 second)
 #eval IO.sleep 1500
 
@@ -34,15 +39,13 @@ info: From: Nat.le_of_succ_le_succ (type: ∀ {n m : Nat}, LE.le n.succ m.succ �
   [apply] apply Nat.le_of_succ_le_succ
   [apply] have : ∀ {n m : Nat}, LE.le n.succ m.succ → LE.le n m := Nat.le_of_succ_le_succ
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : 3 ≤ 5 := by
   #leansearch "If a natural number n is less than m, then the successor of n is less than the successor of m."
   sorry
-
--- Sleep to avoid rate limiting
-#eval IO.sleep 1500
+-/
 
 /--
 warning: #leansearch query should be a string that ends with a `.` or `?`.
@@ -52,9 +55,6 @@ Note this command sends your query to an external service at https://leansearch.
 example : 3 ≤ 5 := by
   #leansearch
   decide
-
--- Sleep to avoid rate limiting
-#eval IO.sleep 1500
 
 /-!
 # Lean Search Examples using `#search`
@@ -75,6 +75,8 @@ Note this command sends your query to an external service at https://leansearch.
 #guard_msgs in
 example := #search "If a natural number n is less than m, then the successor of n is less than the successor of m"
 
+-- Disabled for the same reason as the `#leansearch` tactic test above.
+/-
 -- Sleep to avoid rate limiting
 #eval IO.sleep 1500
 
@@ -85,27 +87,22 @@ info: From: Nat.le_of_succ_le_succ (type: ∀ {n m : Nat}, LE.le n.succ m.succ �
   [apply] apply Nat.le_of_succ_le_succ
   [apply] have : ∀ {n m : Nat}, LE.le n.succ m.succ → LE.le n m := Nat.le_of_succ_le_succ
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : 3 ≤ 5 := by
   #search "If a natural number n is less than m, then the successor of n is less than the successor of m."
   sorry
-
--- Sleep to avoid rate limiting
-#eval IO.sleep 1500
+-/
 
 /--
 warning: #leansearch query should be a string that ends with a `.` or `?`.
 Note this command sends your query to an external service at https://leansearch.net/.
 ---
-warning: declaration uses 'sorry'
+warning: declaration uses `sorry`
 -/
 #guard_msgs in
 example : 3 ≤ 5 := #search
-
--- Sleep to avoid rate limiting
-#eval IO.sleep 1500
 
 set_option leansearchclient.backend "magic"
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.27.0-rc1
+leanprover/lean4:v4.32.0


### PR DESCRIPTION
This PR bumps the toolchain to lean v4.32.0 and fixes or disables breaking tests.

These changes originally come from the https://github.com/leanprover/downstream-lean4 repository.